### PR TITLE
Different column name in setNewOrder method

### DIFF
--- a/src/Spatie/EloquentSortable/Sortable.php
+++ b/src/Spatie/EloquentSortable/Sortable.php
@@ -71,10 +71,12 @@ trait Sortable
         }
 
         $newOrder = 1;
+        $orderColumnName = $this->determineOrderColumnName();
         foreach($ids as $id)
         {
             $model = self::find($id);
-            $model->order_column = $newOrder++;
+            $orderColumnName = $model->determineOrderColumnName();
+            $model->$orderColumnName = $newOrder++;
             $model->save();
         }
     }


### PR DESCRIPTION
For example I have model with order column named as 'priority' and good way is using $sortable config array from model.
